### PR TITLE
Ignore role prefix

### DIFF
--- a/server/authentication/signIn.js
+++ b/server/authentication/signIn.js
@@ -60,7 +60,7 @@ async function getRole(eliteAuthorisationToken, allowedRoles) {
 
     if (roles && roles.length > 0) {
         const role = roles.find(role => {
-            return allowedRoles.includes(role.roleCode);
+            return allowedRoles.includes(role.roleCode.substring(role.roleCode.indexOf('_') + 1));
         });
 
         if (role) {

--- a/test/authentication/signInTest.js
+++ b/test/authentication/signInTest.js
@@ -13,7 +13,7 @@ const fakeNomis = nock(`${config.nomis.apiUrl}`);
 const matchedRole = {
     roleId: 1,
     roleName: 'roleNameValue1',
-    roleCode: 'SOME_ROLE_ALLOWED',
+    roleCode: 'PREFIX_SOME_ROLE_ALLOWED',
     parentRoleCode: 'parentRoleCodeValue1'
 };
 
@@ -110,10 +110,10 @@ describe('signIn', () => {
 
     describe('get roles', () => {
 
-        it('should find first role matching batch user', async () => {
+        it('should find first role matching batch user ignoring prefix', async () => {
             withSuccessResponses();
             const profileResult = await signInService.signIn('user', 'pass', ['SOME_ROLE_ALLOWED']);
-            expect(profileResult.role.roleCode).to.equal('SOME_ROLE_ALLOWED');
+            expect(profileResult.role.roleCode).to.equal('PREFIX_SOME_ROLE_ALLOWED');
         });
 
         it('should return role suffix as role code', async () => {


### PR DESCRIPTION
Role names come out of elite with a prefix for the prison eg LEI_SYSTEM_USER where LEI is the prefix we need to ignore because it could be different for different users
